### PR TITLE
Create test files in a temporary directory

### DIFF
--- a/t/1-basic.t
+++ b/t/1-basic.t
@@ -1,5 +1,7 @@
 use strict;
 use Test::More tests => 23;
+use File::Spec;
+use File::Temp 0.19;
 
 BEGIN { use_ok('PerlIO::eol', qw( eol_is_mixed CR LF CRLF NATIVE )) }
 
@@ -21,77 +23,76 @@ sub is_hex ($$;$) {
     goto &is;
 }
 
+my $directory = File::Temp->newdir;
+my $readfile = File::Spec->catfile($directory, "read");
+my $writefile = File::Spec->catfile($directory, "write");
+
 {
-    open my $w, ">:raw", "read" or die "can't create testfile: $!";
+    open my $w, ">:raw", $readfile or die "can't create testfile: $!";
     print $w "...$CRLF$LF$CR...";
 }
 
 {
-    ok(open(my $r, "<:raw:eol(CR)", "read"), "open for read");
+    ok(open(my $r, "<:raw:eol(CR)", $readfile), "open for read");
     is_hex(<$r>, "...$CR$CR$CR...", "read");
 }
 
 {
-    ok(open(my $r, "<:raw:eol(LF)", "read"), "open for read");
+    ok(open(my $r, "<:raw:eol(LF)", $readfile), "open for read");
     is_hex(<$r>, "...$LF$LF$LF...", "read");
 }
 
 {
-    ok(open(my $r, "<:raw:eol(CRLF)", "read"), "open for read");
+    ok(open(my $r, "<:raw:eol(CRLF)", $readfile), "open for read");
     is_hex(<$r>, "...$CRLF$CRLF$CRLF...", "read");
 }
 
 {
     local $@;
-    ok(open(my $r, "<:raw:eol(CR!)", "read"), "open for read");
+    ok(open(my $r, "<:raw:eol(CR!)", $readfile), "open for read");
     is(eval { <$r> }, undef, 'mixed encoding');
     like($@, qr/Mixed newlines/, 'raises exception');
 }
 
 {
-    ok(open(my $r, "<:raw:eol(CRLF?)", "read"), "open for read");
+    ok(open(my $r, "<:raw:eol(CRLF?)", $readfile), "open for read");
     my $warning;
     local $SIG{__WARN__} = sub { $warning = $_[0] };
     is_hex(<$r>, "...$CRLF$CRLF$CRLF...", "read");
-    like($warning, qr/Mixed newlines found in "read"/, 'raises exception');
+    like($warning, qr/Mixed newlines found in "\Q$readfile\E"/, 'raises exception');
 }
 
 {
     local $@;
-    open my $w, ">:raw:eol(LF!)", "write" or die "can't create testfile: $!";
+    open my $w, ">:raw:eol(LF!)", $writefile or die "can't create testfile: $!";
     eval { print $w "...$CRLF$LF$CR..." };
-    like($@, qr/Mixed newlines found in "write"/, 'raises exception');
+    like($@, qr/Mixed newlines found in "\Q$writefile\E"/, 'raises exception');
 }
 
 TODO: {
     local $@;
     local $TODO = 'Trailing CR in mixed encodings';
-    open my $w, ">:raw:eol(LF!)", "write" or die "can't create testfile: $!";
+    open my $w, ">:raw:eol(LF!)", $writefile or die "can't create testfile: $!";
     eval { print $w "...$CRLF$CR" };
-    like($@, qr/Mixed newlines found in "write"/, 'raises exception');
+    like($@, qr/Mixed newlines found in "\Q$writefile\E"/, 'raises exception');
 }
 
 {
-    ok(open(my $w, ">:raw:eol(CrLf-lf)", "write"), "open for write");
+    ok(open(my $w, ">:raw:eol(CrLf-lf)", $writefile), "open for write");
     print $w "...$CR$LF...";
 }
 
 {
-    open my $r, "<:raw", "write" or die "can't read testfile: $!";
+    open my $r, "<:raw", $writefile or die "can't read testfile: $!";
     is_hex(<$r>, "...$LF...", "write");
 }
 
 {
-    ok(open(my $w, ">:raw:eol(LF-Native)", "write"), "open for write");
+    ok(open(my $w, ">:raw:eol(LF-Native)", $writefile), "open for write");
     print $w "...$CR";
 }
 
 {
-    open my $r, "<", "write" or die "can't read testfile: $!";
+    open my $r, "<", $writefile or die "can't read testfile: $!";
     is_hex(<$r>, "...\n", "write");
-}
-
-END {
-    unlink "read";
-    unlink "write";
 }


### PR DESCRIPTION
Running the tests from a read-only location fails:

    $ perl t/1-basic.t
    1..23
    ok 1 - use PerlIO::eol;
    ok 2
    ok 3
    ok 4
    ok 5
    can't create testfile: Permission denied at t/1-basic.t line 26.
    # Looks like your test exited with 13 just after 5.
    #

This patch fixes it by creating the test files in temporary directory made with File::Temp. It's not a new dependency, File::Temp is already used by t/00-compile.t.